### PR TITLE
Add ggadvancedimages module

### DIFF
--- a/ggadvancedimages/README.md
+++ b/ggadvancedimages/README.md
@@ -1,0 +1,19 @@
+# GG Advanced Images
+
+## About
+
+This module demonstrates how to attach alternative product images depending on customer login state and language. It extends the product edit form with additional fields and replaces images in the front office when required.
+
+### Supported PrestaShop versions
+
+Compatible with 9.0.0 and above.
+
+### Requirements
+
+1. Composer
+
+### How to install
+
+1. Copy the module into the `modules` directory of your PrestaShop installation and rename the folder to `ggadvancedimages` if needed.
+2. `cd` into the module's directory and run `composer install` to generate the autoloader.
+3. Install the module from the Back Office.

--- a/ggadvancedimages/composer.json
+++ b/ggadvancedimages/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "prestashop/ggadvancedimages",
+  "autoload": {
+    "psr-4": {
+      "PrestaShop\\Module\\Ggadvancedimages\\": "src/"
+    },
+    "config": {
+      "prepend-autoloader": false
+    },
+    "type": "prestashop-module"
+  }
+}

--- a/ggadvancedimages/config.xml
+++ b/ggadvancedimages/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<module>
+    <name>ggadvancedimages</name>
+    <displayName><![CDATA[GG Advanced Images]]></displayName>
+    <version><![CDATA[1.0.0]]></version>
+    <description><![CDATA[Provide guest or logged-in specific product images per language.]]></description>
+    <author><![CDATA[Example]]></author>
+    <tab><![CDATA[]]></tab>
+    <is_configurable>0</is_configurable>
+    <need_instance>1</need_instance>
+</module>

--- a/ggadvancedimages/ggadvancedimages.php
+++ b/ggadvancedimages/ggadvancedimages.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use PrestaShop\Module\Ggadvancedimages\Form\Modifier\ProductFormModifier;
+use PrestaShop\Module\Ggadvancedimages\Install\Installer;
+use PrestaShop\Module\Ggadvancedimages\Repository\AdvancedImageRepository;
+use PrestaShop\Module\Ggadvancedimages\Uploader\AdvancedImageUploader;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once __DIR__.'/vendor/autoload.php';
+
+class Ggadvancedimages extends Module
+{
+    public function __construct()
+    {
+        $this->name = 'ggadvancedimages';
+        $this->author = 'Example';
+        $this->version = '1.0.0';
+        $this->ps_versions_compliancy = ['min' => '9.0.0', 'max' => '9.99.99'];
+        parent::__construct();
+
+        $this->displayName = $this->l('GG Advanced Images');
+        $this->description = $this->l('Adds language and user specific product images.');
+    }
+
+    public function install(): bool
+    {
+        if (!parent::install()) {
+            return false;
+        }
+
+        $installer = new Installer();
+        return $installer->install($this);
+    }
+
+    public function uninstall(): bool
+    {
+        $installer = new Installer();
+        return $installer->uninstall($this) && parent::uninstall();
+    }
+
+    public function hookActionProductFormBuilderModifier(array $params): void
+    {
+        /** @var ProductFormModifier $modifier */
+        $modifier = $this->get(ProductFormModifier::class);
+        $modifier->modify($params['form_builder']);
+    }
+
+    public function hookActionAfterCreateProductFormHandler(array $params): void
+    {
+        $this->handleImageUpload($params);
+    }
+
+    public function hookActionAfterUpdateProductFormHandler(array $params): void
+    {
+        $this->handleImageUpload($params);
+    }
+
+    private function handleImageUpload(array $params): void
+    {
+        /** @var UploadedFile $file */
+        $file = $params['form_data']['gg_image_file'] ?? null;
+        $lang = (int)($params['form_data']['gg_image_lang'] ?? 0);
+        $isGuest = (bool)($params['form_data']['gg_image_user'] ?? 1);
+
+        if ($file instanceof UploadedFile) {
+            $repo = new AdvancedImageRepository();
+            $uploader = new AdvancedImageUploader($repo);
+            $uploader->upload((int)$params['id'], $file, $lang, $isGuest);
+        }
+    }
+
+    public function hookActionGetProductPropertiesAfter(array $params): void
+    {
+        $product = &$params['product'];
+        $repo = new AdvancedImageRepository();
+        $isGuest = $this->context->customer->isLogged() ? 0 : 1;
+        $record = $repo->find((int)$product['id_product'], (int)$this->context->language->id, (bool)$isGuest);
+        if ($record) {
+            $product['cover'] = _MODULE_DIR_.'ggadvancedimages/uploads/'.$record['image_name'];
+        }
+    }
+}

--- a/ggadvancedimages/src/Form/Modifier/ProductFormModifier.php
+++ b/ggadvancedimages/src/Form/Modifier/ProductFormModifier.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Ggadvancedimages\Form\Modifier;
+
+use Language;
+use PrestaShopBundle\Form\FormBuilderModifier;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ProductFormModifier
+{
+    public function __construct(private readonly FormBuilderModifier $modifier)
+    {
+    }
+
+    public function modify(FormBuilderInterface $builder): void
+    {
+        $choices = [];
+        foreach (Language::getLanguages(false) as $lang) {
+            $choices[$lang['name']] = $lang['id_lang'];
+        }
+
+        $this->modifier->addAfter(
+            $builder,
+            'basic',
+            'gg_image_file',
+            FileType::class,
+            [
+                'required' => false,
+                'label' => 'Advanced image',
+            ]
+        );
+
+        $this->modifier->addAfter(
+            $builder,
+            'gg_image_file',
+            'gg_image_lang',
+            ChoiceType::class,
+            [
+                'label' => 'Language',
+                'choices' => $choices,
+                'expanded' => true,
+                'multiple' => false,
+            ]
+        );
+
+        $this->modifier->addAfter(
+            $builder,
+            'gg_image_lang',
+            'gg_image_user',
+            ChoiceType::class,
+            [
+                'label' => 'User type',
+                'choices' => [
+                    'Guests' => 1,
+                    'Logged in' => 0,
+                ],
+                'expanded' => true,
+            ]
+        );
+    }
+}

--- a/ggadvancedimages/src/Install/Installer.php
+++ b/ggadvancedimages/src/Install/Installer.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Ggadvancedimages\Install;
+
+use Db;
+use Module;
+use PrestaShopBundle\Install\SqlLoader;
+
+class Installer
+{
+    public function install(Module $module): bool
+    {
+        if (!$this->registerHooks($module)) {
+            return false;
+        }
+
+        if (!$this->executeSqlFromFile($module->getLocalPath().'src/Install/install.sql')) {
+            return false;
+        }
+
+        if (!is_dir(_PS_MODULE_DIR_.'ggadvancedimages/uploads/')) {
+            mkdir(_PS_MODULE_DIR_.'ggadvancedimages/uploads/', 0755, true);
+        }
+
+        return true;
+    }
+
+    public function uninstall(Module $module): bool
+    {
+        return $this->executeSqlFromFile($module->getLocalPath().'src/Install/uninstall.sql');
+    }
+
+    private function registerHooks(Module $module): bool
+    {
+        $hooks = [
+            'actionProductFormBuilderModifier',
+            'actionAfterCreateProductFormHandler',
+            'actionAfterUpdateProductFormHandler',
+            'actionGetProductPropertiesAfter',
+        ];
+
+        return (bool) $module->registerHook($hooks);
+    }
+
+    private function executeSqlFromFile(string $file): bool
+    {
+        if (!file_exists($file)) {
+            return true;
+        }
+
+        $allowedCollations = ['utf8mb4_general_ci', 'utf8mb4_unicode_ci'];
+        $databaseCollation = Db::getInstance()->getValue('SELECT @@collation_database');
+        $loader = new SqlLoader();
+        $loader->setMetaData([
+            'PREFIX_' => _DB_PREFIX_,
+            'ENGINE_TYPE' => _MYSQL_ENGINE_,
+            'COLLATION' => (empty($databaseCollation) || !in_array($databaseCollation, $allowedCollations)) ? '' : 'COLLATE ' . $databaseCollation,
+        ]);
+
+        return $loader->parseFile($file);
+    }
+}

--- a/ggadvancedimages/src/Install/install.sql
+++ b/ggadvancedimages/src/Install/install.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `PREFIX_ggadvancedimages` (
+    `id_image` INT(11) NOT NULL AUTO_INCREMENT,
+    `id_product` INT(11) NOT NULL,
+    `id_lang` INT(11) NOT NULL,
+    `is_guest` TINYINT(1) NOT NULL DEFAULT 1,
+    `image_name` VARCHAR(255) NOT NULL,
+    UNIQUE KEY `image_unique` (`id_product`,`id_lang`,`is_guest`),
+    PRIMARY KEY (`id_image`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8;

--- a/ggadvancedimages/src/Install/uninstall.sql
+++ b/ggadvancedimages/src/Install/uninstall.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `PREFIX_ggadvancedimages`;

--- a/ggadvancedimages/src/Repository/AdvancedImageRepository.php
+++ b/ggadvancedimages/src/Repository/AdvancedImageRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Ggadvancedimages\Repository;
+
+use Db;
+
+class AdvancedImageRepository
+{
+    public function upsert(int $productId, int $langId, bool $isGuest, string $imageName): void
+    {
+        $sql = 'REPLACE INTO `'._DB_PREFIX_.'ggadvancedimages` (`id_product`,`id_lang`,`is_guest`,`image_name`)' .
+            ' VALUES (' . (int)$productId . ',' . (int)$langId . ',' . (int)$isGuest . ',\'' . pSQL($imageName) . '\')';
+        Db::getInstance()->execute($sql);
+    }
+
+    public function find(int $productId, int $langId, bool $isGuest): ?array
+    {
+        return Db::getInstance()->getRow(
+            'SELECT * FROM `'._DB_PREFIX_.'ggadvancedimages` WHERE id_product='.(int)$productId.
+            ' AND id_lang='.(int)$langId.' AND is_guest='.(int)$isGuest
+        );
+    }
+}

--- a/ggadvancedimages/src/Uploader/AdvancedImageUploader.php
+++ b/ggadvancedimages/src/Uploader/AdvancedImageUploader.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\Ggadvancedimages\Uploader;
+
+use PrestaShop\Module\Ggadvancedimages\Repository\AdvancedImageRepository;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageOptimizationException;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageUploadException;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\MemoryLimitException;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
+use PrestaShop\PrestaShop\Core\Image\Uploader\ImageUploaderInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class AdvancedImageUploader implements ImageUploaderInterface
+{
+    private const UPLOAD_PATH = _PS_MODULE_DIR_ . 'ggadvancedimages/uploads/';
+
+    public function __construct(private readonly AdvancedImageRepository $repository)
+    {
+    }
+
+    public function upload($productId, UploadedFile $image, int $langId, bool $isGuest): void
+    {
+        $this->checkImageIsAllowedForUpload($image);
+        $tmp = $this->createTemporaryImage($image);
+        $name = $image->getClientOriginalName();
+        $destination = self::UPLOAD_PATH . $name;
+        $this->uploadFromTemp($tmp, $destination);
+        $this->repository->upsert((int)$productId, $langId, $isGuest, $name);
+    }
+
+    protected function createTemporaryImage(UploadedFile $image): string
+    {
+        $tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS');
+        if (!$tmpName || !move_uploaded_file($image->getPathname(), $tmpName)) {
+            throw new ImageUploadException('Failed to create temporary image file');
+        }
+
+        return $tmpName;
+    }
+
+    protected function uploadFromTemp(string $tmpName, string $destination): void
+    {
+        if (!\ImageManager::checkImageMemoryLimit($tmpName)) {
+            throw new MemoryLimitException('Cannot upload image due to memory restrictions');
+        }
+
+        if (!\ImageManager::resize($tmpName, $destination)) {
+            throw new ImageOptimizationException('An error occurred while uploading the image.');
+        }
+
+        unlink($tmpName);
+    }
+
+    protected function checkImageIsAllowedForUpload(UploadedFile $image): void
+    {
+        $maxFileSize = \Tools::getMaxUploadSize();
+        if ($maxFileSize > 0 && $image->getSize() > $maxFileSize) {
+            throw new UploadedImageConstraintException('Max file size exceeded', UploadedImageConstraintException::EXCEEDED_SIZE);
+        }
+
+        if (!\ImageManager::isRealImage($image->getPathname(), $image->getClientMimeType())
+            || !\ImageManager::isCorrectImageFileExt($image->getClientOriginalName())
+            || preg_match('/\%00/', $image->getClientOriginalName())
+        ) {
+            throw new UploadedImageConstraintException('Image format not recognized', UploadedImageConstraintException::UNRECOGNIZED_FORMAT);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ggadvancedimages example module
- implement install routine with table creation and hooks
- allow uploading language/user specific images in product form
- switch product cover image on front office according to login state

## Testing
- `php -l ggadvancedimages/ggadvancedimages.php`
- `php -l ggadvancedimages/src/Install/Installer.php`
- `php -l ggadvancedimages/src/Repository/AdvancedImageRepository.php`
- `php -l ggadvancedimages/src/Uploader/AdvancedImageUploader.php`
- `php -l ggadvancedimages/src/Form/Modifier/ProductFormModifier.php`

------
https://chatgpt.com/codex/tasks/task_e_685181d1214c8324bbaa89e04e8a6a1c